### PR TITLE
Rename v2 branch name

### DIFF
--- a/_posts/2016-11-15-v2-plan.md
+++ b/_posts/2016-11-15-v2-plan.md
@@ -27,8 +27,9 @@ This will change the way how to develop Chainer and CuPy, and also how to instal
 
 The version 2 will be developed in a different style from the usual minor updates:
 
-- The development will run on v2 branch, and keep the master branch developing the currently running v1.
-- The v2 branch will use a new CuPy repository.
+- The development will run on `_v2` branch, and keep the master branch developing the currently running v1.
+	- (Update) The branch is renamed to `_v2` to avoid problems around readthedocs.
+- The `_v2` branch will use a new CuPy repository.
 - Issues and PRs for v2 will be labeled as "v2."
 - We will continue the development of v1 before the release of v2 (including CuPy). At each minor release, features included in it will be ported to v2.
 - Features whose APIs are changed in v2 will be deprecated, and if the change is critical, they will raise FutureWarning.

--- a/_posts/2016-11-15-v2-plan.md
+++ b/_posts/2016-11-15-v2-plan.md
@@ -28,7 +28,7 @@ This will change the way how to develop Chainer and CuPy, and also how to instal
 The version 2 will be developed in a different style from the usual minor updates:
 
 - The development will run on `_v2` branch, and keep the master branch developing the currently running v1.
-	- (Update) The branch is renamed to `_v2` to avoid problems around readthedocs.
+	- (Update) The branch `v2` is renamed to `_v2` to avoid problems around readthedocs.
 - The `_v2` branch will use a new CuPy repository.
 - Issues and PRs for v2 will be labeled as "v2."
 - We will continue the development of v1 before the release of v2 (including CuPy). At each minor release, features included in it will be ported to v2.


### PR DESCRIPTION
In order to avoid the v2 branch being treated as a stable one by readthedocs, we renamed it to `_v2`. This PR fixes the blog post for it.