### PR TITLE
Fix header icon link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,7 +11,7 @@
 
 <!-- Header -->
 <header id="header" class="skel-layers-fixed">
-    <h1><a href="{{ site.baseurl }}"><img src="{{ site.baseurl }}/images/chainer_icon_red.png" style="height: 100%" alt="Chainer"/></a></h1>
+    <h1><a href="{{ site.baseurl }}/"><img src="{{ site.baseurl }}/images/chainer_icon_red.png" style="height: 100%" alt="Chainer"/></a></h1>
     <nav id="nav">
 	    <ul>
             <li id="twitter_share">


### PR DESCRIPTION
The header icon links to the current page. This change fixes it to make it always link to the home page (/).