### PR TITLE
Change cdn for mathjax

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -22,7 +22,8 @@
     <script src="{{ site.baseurl }}/js/skel.min.js"></script>
     <script src="{{ site.baseurl }}/js/skel-layers.min.js"></script>
     <script src="{{ site.baseurl }}/js/init.js"></script>
-    <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/config/TeX-AMS-MML_HTMLorMML.js" type="text/javascript"></script>
     <noscript>
         <link rel="stylesheet" href="{{ site.baseurl }}/css/skel.css" />
         <link rel="stylesheet" href="{{ site.baseurl }}/css/style.css" />


### PR DESCRIPTION
cdn.mathjax.org is closed.  I replaced it with cdnjs.

https://www.mathjax.org/cdn-shutting-down/