### PR TITLE
remove chainermn in top page

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,19 +78,6 @@ python chainer-{{ site.chainer_version }}/examples/mnist/train_mnist.py</code></
         </header>
         <div class="row extensions">
             <div class="4u">
-                <div class="extension-item" id="chainermn">
-                    <a href="https://github.com/chainer/chainermn">
-                        <div class="extension-cover"></div>
-                    </a>
-                    <div class="extension-icon">
-                        <img src="images/MN1-2.png" alt="ChainerMN" />
-                    </div>
-                    <div class="extension-content">
-                        An extension package that enables multi-node distributed deep learning.
-                    </div>
-                </div>
-            </div>
-            <div class="4u">
                 <div class="extension-item" id="chainerrl">
                     <a href="https://github.com/chainer/chainerrl">
                         <div class="extension-cover"></div>


### PR DESCRIPTION
This PR removes ChainerMN part in top page becase ChainerMN was merged to Chainer. 